### PR TITLE
Adds maximum uptime of 45 minutes for each database type

### DIFF
--- a/mssql2017Host/ready.sh
+++ b/mssql2017Host/ready.sh
@@ -12,7 +12,13 @@ export DATABASE_COUNT=`/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "SQLSer
 
 echo "Found ${DATABASE_COUNT} MS SQL fiddle databases"
 
-if [ $DATABASE_COUNT -gt 25 ]
+export CREATED_TIME=`stat -c "%Z" /proc/1/`
+export CURRENT_TIME=`date +%s`
+export UPTIME_SECONDS=`expr $CURRENT_TIME - $CREATED_TIME`
+export UPTIME_MINUTES=`echo $(($UPTIME_SECONDS / 60))`
+echo "Up for ${UPTIME_MINUTES} minutes"
+
+if [ $DATABASE_COUNT -gt 25 ] || [ $UPTIME_MINUTES -gt 45 ]
 then
   exit 1
 else

--- a/mysql56Host/ready.sh
+++ b/mysql56Host/ready.sh
@@ -6,7 +6,13 @@ export DATABASE_COUNT=`mysql -u root -ppassword mysql -e "show databases like 'd
 
 echo "Found ${DATABASE_COUNT} MySQL fiddle databases"
 
-if [ $DATABASE_COUNT -gt 50 ]
+export CREATED_TIME=`stat -c "%Z" /proc/1/`
+export CURRENT_TIME=`date +%s`
+export UPTIME_SECONDS=`expr $CURRENT_TIME - $CREATED_TIME`
+export UPTIME_MINUTES=`echo $(($UPTIME_SECONDS / 60))`
+echo "Up for ${UPTIME_MINUTES} minutes"
+
+if [ $DATABASE_COUNT -gt 50 ] || [ $UPTIME_MINUTES -gt 45 ]
 then
   exit 1
 else

--- a/oracle11gHost/ready.sh
+++ b/oracle11gHost/ready.sh
@@ -11,7 +11,13 @@ fi
 
 CAPACITY=`su -p oracle -c "echo \"SELECT CASE WHEN count(*) < 50 THEN 'REA'||'DY' ELSE 'OVERCAPACITY' END as status FROM (select distinct lower(replace(USERNAME, 'USER', 'DB')) as schema_name from all_users) tmp WHERE schema_name LIKE 'db_%';\" | sqlplus system/password as sysdba" | grep READY`
 
-if [ "$CAPACITY" != "READY" ]
+export CREATED_TIME=`stat -c "%Z" /proc/1/`
+export CURRENT_TIME=`date +%s`
+export UPTIME_SECONDS=`expr $CURRENT_TIME - $CREATED_TIME`
+export UPTIME_MINUTES=`echo $(($UPTIME_SECONDS / 60))`
+echo "Up for ${UPTIME_MINUTES} minutes"
+
+if [ "$CAPACITY" != "READY" ] || [ $UPTIME_MINUTES -gt 45 ]
 then
   echo "Overcapacity"
   exit 1

--- a/postgresql93Host/ready.sh
+++ b/postgresql93Host/ready.sh
@@ -6,7 +6,13 @@ export DATABASE_COUNT=`psql -U postgres postgres -A -t -c "select datname from p
 
 echo "Found ${DATABASE_COUNT} PostgreSQL fiddle databases"
 
-if [ $DATABASE_COUNT -gt 50 ]
+export CREATED_TIME=`stat -c "%Z" /proc/1/`
+export CURRENT_TIME=`date +%s`
+export UPTIME_SECONDS=`expr $CURRENT_TIME - $CREATED_TIME`
+export UPTIME_MINUTES=`echo $(($UPTIME_SECONDS / 60))`
+echo "Up for ${UPTIME_MINUTES} minutes"
+
+if [ $DATABASE_COUNT -gt 50 ] || [ $UPTIME_MINUTES -gt 45 ]
 then
   exit 1
 else

--- a/postgresql96Host/ready.sh
+++ b/postgresql96Host/ready.sh
@@ -6,7 +6,13 @@ export DATABASE_COUNT=`psql -U postgres postgres -A -t -c "select datname from p
 
 echo "Found ${DATABASE_COUNT} PostgreSQL fiddle databases"
 
-if [ $DATABASE_COUNT -gt 50 ]
+export CREATED_TIME=`stat -c "%Z" /proc/1/`
+export CURRENT_TIME=`date +%s`
+export UPTIME_SECONDS=`expr $CURRENT_TIME - $CREATED_TIME`
+export UPTIME_MINUTES=`echo $(($UPTIME_SECONDS / 60))`
+echo "Up for ${UPTIME_MINUTES} minutes"
+
+if [ $DATABASE_COUNT -gt 50 ] || [ $UPTIME_MINUTES -gt 45 ]
 then
   echo "Overcapacity"
   exit 1

--- a/prodValues.yaml
+++ b/prodValues.yaml
@@ -3,8 +3,8 @@
 
 registryPrefix: 321080263678.dkr.ecr.us-west-2.amazonaws.com/sqlfiddle
 
-mssql2017Version: 1.0.2
-oracle11gVersion: 1.0.0
+mssql2017Version: 1.0.3
+oracle11gVersion: 1.0.1
 
 sqlfiddleOpenCore:
   appServerReplicas: 2
@@ -16,6 +16,6 @@ sqlfiddleOpenCore:
   appServerVersion: 2.0.4
   varnishVersion: 1.0.0
   hostMonitorVersion: 1.0.0
-  mysql56Version: 1.0.0
-  postgresql93Version: 1.0.0
-  postgresql96Version: 1.0.0
+  mysql56Version: 1.0.1
+  postgresql93Version: 1.0.1
+  postgresql96Version: 1.0.1


### PR DESCRIPTION
Should prevent unnecessary restarts. In the worse case, each database environment will live for only 45 minutes before being scheduled for a restart. During times of heavy usage, the database will still restart more regularly.